### PR TITLE
Specs and activation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Akamai API for changes to Property Manager etc via CLI
 
 ## Setup
 
-This step assumes you have ruby 2.3.1 install on local
+This step assumes you have ruby 2.3.1 ot 2.4.2 installed on local
 1. Get credentials in Akamai control panel (Luna)
 
 https://developer.akamai.com/introduction/Prov_Creds.html

--- a/bin/acm
+++ b/bin/acm
@@ -8,24 +8,24 @@ class AkamaiCloudletManagerCli < Thor
   desc "get_policy_version", "Get policy versions"
   long_desc <<-LONGDESC
   Get the policy versions.
-    With --policy, policy on which version to be cloned
+    With --policy_id, policy on which version to be cloned
     LONGDESC
-  option :policy, required: true
-  def get_policy_version(policy_id)
+  option :policy_id, required: true
+  def get_policy_version
     puts "Policy version:"
-    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy] })
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy_id] })
     puts policy_version.versions
   end
 
   desc "clone_policy_version", "Clones the current policy version"
   long_desc <<-LONGDESC
   Clones the current activated version of a policy. All new updates are performed in cloned version
-    With --policy, policy on which version to be cloned
+    With --policy_id, policy on which version to be cloned
     LONGDESC
-  option :policy, required: true
-  def clone_policy_version(policy_id)
+  option :policy_id, required: true
+  def clone_policy_version
     puts "clones the policy version"
-    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy] })
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy_id] })
     begin
       latest_version = JSON.parse(policy_version.versions).first["version"].to_s
       policy_version.create(latest_version)
@@ -45,13 +45,13 @@ class AkamaiCloudletManagerCli < Thor
 
     LONGDESC
 
-  option :policy,  required: true
+  option :policy_id,  required: true
   option :draft_version, required: true
   option :file_path, required: true
   def update_policy_version
     puts "updates the policy version"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({
-                                                                policy_id: options[:policy],
+                                                                policy_id: options[:policy_id],
                                                                 version_id: options[:draft_version]
                                                               })
     begin
@@ -68,20 +68,23 @@ class AkamaiCloudletManagerCli < Thor
   desc "activate_policy_version", "Activate the policy version on a given network(staging/production)"
   long_desc <<-LONGDESC
   Activates the policy version
-    With --policy, policy on which version to be activated
+    With --policy_id, policy on which version to be activated
     With --version, version which needs to be activated
     With --network, network on which policy version needs to be activated
 
     LONGDESC
-  option :policy,  required: true
+  option :policy_id,  required: true
   option :version, required: true
   option :network, required: true
   def activate_policy_version
     puts "activates the policy version"
-    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy], version_id: options[:version] })
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({
+                                                                policy_id: options[:policy_id],
+                                                                version_id: options[:version]
+                                                              })
     begin
       puts options[:network]
-      puts options[:policy]
+      puts options[:policy_id]
       puts options[:version]
       puts policy_version.activate(network)
     rescue => err

--- a/bin/acm
+++ b/bin/acm
@@ -5,23 +5,90 @@ require 'thor'
 
 class AkamaiCloudletManagerCli < Thor
 
-  desc "clone_version", "Clones the current version"
+  desc "get_policy_version", "Get policy versions"
   long_desc <<-LONGDESC
-  Clones the current activated version. All new updates are performed in cloned version
+  Get the policy versions.
+    With --policy, policy on which version to be cloned
     LONGDESC
-  def clone_version
-    puts "clones the version"
+  option :policy, required: true
+  def get_policy_version(policy_id)
+    puts "Policy version:"
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy] })
+    puts policy_version.versions
   end
 
-  desc "update_version", "Updates the version"
+  desc "clone_policy_version", "Clones the current policy version"
   long_desc <<-LONGDESC
-  Updates the version
-    With --version, version which needs to be updated
+  Clones the current activated version of a policy. All new updates are performed in cloned version
+    With --policy, policy on which version to be cloned
+    LONGDESC
+  option :policy, required: true
+  def clone_policy_version(policy_id)
+    puts "clones the policy version"
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy] })
+    begin
+      latest_version = JSON.parse(policy_version.versions).first["version"].to_s
+      policy_version.create(latest_version)
+    rescue => err
+      puts "cloning failed!"
+      puts "Exception: #{err}"
+      err
+    end
+  end
+
+  desc "update_policy_version", "Updates the policy version"
+  long_desc <<-LONGDESC
+  Updates the policy version. A policy version can be updated only in draft mode not when it is activated.
+    With --policy, policy on which version to be updated
+    With --draft_version, version which needs to be updated, this must be inactive version
+    With --file_path, file_path from which rules can be constructed and updated to policy version
 
     LONGDESC
+
+  option :policy,  required: true
+  option :draft_version, required: true
+  option :file_path, required: true
+  def update_policy_version
+    puts "updates the policy version"
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({
+                                                                policy_id: options[:policy],
+                                                                version_id: options[:draft_version]
+                                                              })
+    begin
+      version_rules = policy_version.generate_rules(options[:file_path])
+      puts version_rules
+      puts policy_version.update(version_rules)
+    rescue => err
+      puts "update failed!"
+      puts "Exception: #{err}"
+      err
+    end
+  end
+
+  desc "activate_policy_version", "Activate the policy version on a given network(staging/production)"
+  long_desc <<-LONGDESC
+  Activates the policy version
+    With --policy, policy on which version to be activated
+    With --version, version which needs to be activated
+    With --network, network on which policy version needs to be activated
+
+    LONGDESC
+  option :policy,  required: true
   option :version, required: true
-  def update_version
-    puts "Updating to version: #{options[:version]}"
+  option :network, required: true
+  def activate_policy_version
+    puts "activates the policy version"
+    policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy], version_id: options[:version] })
+    begin
+      puts options[:network]
+      puts options[:policy]
+      puts options[:version]
+      puts policy_version.activate(network)
+    rescue => err
+      puts "activation failed!"
+      puts "Exception: #{err}"
+      err
+    end
   end
 
 end

--- a/bin/acm
+++ b/bin/acm
@@ -5,13 +5,13 @@ require 'thor'
 
 class AkamaiCloudletManagerCli < Thor
 
-  desc "get_policy_version", "Get policy versions"
+  desc "get_policy_versions", "Get policy versions"
   long_desc <<-LONGDESC
   Get the policy versions.
     With --policy_id, policy on which version to be cloned
     LONGDESC
-  option :policy_id, required: true
-  def get_policy_version
+  method_option :policy_id, required: true
+  def get_policy_versions
     puts "Policy version:"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy_id] })
     puts policy_version.versions
@@ -22,13 +22,18 @@ class AkamaiCloudletManagerCli < Thor
   Clones the current activated version of a policy. All new updates are performed in cloned version
     With --policy_id, policy on which version to be cloned
     LONGDESC
-  option :policy_id, required: true
+  method_option :policy_id, required: true
   def clone_policy_version
     puts "clones the policy version"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy_id] })
     begin
-      latest_version = JSON.parse(policy_version.versions).first["version"].to_s
-      policy_version.create(latest_version)
+      if !policy_version.versions.empty?
+        latest_version = JSON.parse(policy_version.versions).first["version"].to_s
+        p latest_version
+        # policy_version.create(latest_version)
+      else
+        puts "No policy versions available"
+      end
     rescue => err
       puts "cloning failed!"
       puts "Exception: #{err}"
@@ -45,9 +50,9 @@ class AkamaiCloudletManagerCli < Thor
 
     LONGDESC
 
-  option :policy_id,  required: true
-  option :draft_version, required: true
-  option :file_path, required: true
+  method_option :policy_id,  required: true
+  method_option :draft_version, required: true
+  method_option :file_path, required: true
   def update_policy_version
     puts "updates the policy version"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({
@@ -73,9 +78,9 @@ class AkamaiCloudletManagerCli < Thor
     With --network, network on which policy version needs to be activated
 
     LONGDESC
-  option :policy_id,  required: true
-  option :version, required: true
-  option :network, required: true
+  method_option :policy_id,  required: true
+  method_option :version, required: true
+  method_option :network, required: true, enum: ['staging','production']
   def activate_policy_version
     puts "activates the policy version"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({

--- a/lib/akamai_cloudlet_manager.rb
+++ b/lib/akamai_cloudlet_manager.rb
@@ -3,3 +3,17 @@ require 'akamai_cloudlet_manager/detail'
 require 'akamai_cloudlet_manager/origin'
 require 'akamai_cloudlet_manager/policy_version'
 require 'akamai_cloudlet_manager/policy'
+
+module AkamaiCloudletManager
+  def self.root
+    File.expand_path '../..', __FILE__
+  end
+
+  def self.lib
+    File.join root, 'lib'
+  end
+
+  def self.spec
+    File.join root, 'spec'
+  end
+end

--- a/lib/akamai_cloudlet_manager/base.rb
+++ b/lib/akamai_cloudlet_manager/base.rb
@@ -6,7 +6,10 @@ require 'json'
 module AkamaiCloudletManager
   class Base
     def initialize(options = {})
-      @http_host = Akamai::Edgegrid::HTTP.new(get_host(), 443)
+      path_to_edgerc = options[:path_to_edgerc] || '~/.edgerc'
+      section        = options[:section] || 'default'
+
+      @http_host = Akamai::Edgegrid::HTTP.new(get_host(path_to_edgerc, section), 443)
       @base_uri  = URI('https://' + @http_host.host)
 
       @http_host.setup_from_edgerc({ section: 'default' })

--- a/lib/akamai_cloudlet_manager/policy.rb
+++ b/lib/akamai_cloudlet_manager/policy.rb
@@ -1,5 +1,5 @@
 module AkamaiCloudletManager
-  class PolicyVersion < Base
+  class Policy < Base
     def initialize(options = {})
       @policy_id  = options[:policy_id]
       super

--- a/lib/akamai_cloudlet_manager/policy_version.rb
+++ b/lib/akamai_cloudlet_manager/policy_version.rb
@@ -59,7 +59,7 @@ module AkamaiCloudletManager
     end
 
     # Update policy version, all rules
-    def update(policy_version_rules)
+    def update(policy_version_rules = {})
       request = Net::HTTP::Put.new(
           URI.join(@base_uri.to_s, "cloudlets/api/v2/policies/#{@policy_id}/versions/#{@version_id}?omitRules=false&matchRuleFormat=1.0").to_s,
           { 'Content-Type' => 'application/json'}

--- a/lib/akamai_cloudlet_manager/policy_version.rb
+++ b/lib/akamai_cloudlet_manager/policy_version.rb
@@ -71,5 +71,20 @@ module AkamaiCloudletManager
       response.body
     end
 
+    def generate_rules(file_path)
+      counter = 1
+      begin
+          file = File.new(file_path, "r")
+          while (line = file.gets)
+              puts "#{counter}: #{line}"
+              counter = counter + 1
+          end
+          file.close
+      rescue => err
+          puts "Exception: #{err}"
+          err
+      end
+    end
+
   end
 end

--- a/spec/akamai_cloudlet_manager/base_spec.rb
+++ b/spec/akamai_cloudlet_manager/base_spec.rb
@@ -4,10 +4,16 @@ require 'spec_helper'
 RSpec.describe AkamaiCloudletManager::Base do
 
   describe '#initialize' do
-    subject { AkamaiCloudletManager::Base.new({}) }
+    subject {
+      AkamaiCloudletManager::Base.new({
+        path_to_edgerc: AkamaiCloudletManager.spec + '/test_edgerc',
+        section:        'test_edgerc'
+      })
+    }
 
     describe 'attributes' do
       it 'http_host' do
+        p subject.instance_variable_get(:@http_host)
         expect(subject.instance_variable_get(:@http_host).class).to eq(Akamai::Edgegrid::HTTP)
       end
 

--- a/spec/akamai_cloudlet_manager/base_spec.rb
+++ b/spec/akamai_cloudlet_manager/base_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+
+RSpec.describe AkamaiCloudletManager::Base do
+
+  describe '#initialize' do
+    subject { AkamaiCloudletManager::Base.new({}) }
+
+    describe 'attributes' do
+      it 'http_host' do
+        expect(subject.instance_variable_get(:@http_host).class).to eq(Akamai::Edgegrid::HTTP)
+      end
+
+      it 'base_uri' do
+        expect(subject.instance_variable_get(:@base_uri).class).to eq(URI::HTTPS)
+      end
+    end
+  end
+end

--- a/spec/akamai_cloudlet_manager/base_spec.rb
+++ b/spec/akamai_cloudlet_manager/base_spec.rb
@@ -13,12 +13,11 @@ RSpec.describe AkamaiCloudletManager::Base do
 
     describe 'attributes' do
       it 'http_host' do
-        p subject.instance_variable_get(:@http_host)
-        expect(subject.instance_variable_get(:@http_host).class).to eq(Akamai::Edgegrid::HTTP)
+        expect(subject.instance_variable_get(:@http_host)).to be_kind_of(Akamai::Edgegrid::HTTP)
       end
 
       it 'base_uri' do
-        expect(subject.instance_variable_get(:@base_uri).class).to eq(URI::HTTPS)
+        expect(subject.instance_variable_get(:@base_uri)).to be_kind_of(URI::HTTPS)
       end
     end
   end

--- a/spec/akamai_cloudlet_manager/detail_spec.rb
+++ b/spec/akamai_cloudlet_manager/detail_spec.rb
@@ -4,9 +4,16 @@ require 'spec_helper'
 RSpec.describe AkamaiCloudletManager::Detail do
 
   describe '#initialize' do
+    subject { AkamaiCloudletManager::Detail.new({ cloudlet_id: '123', group_id: '456' }) }
 
-    it 'should do something' do
-      expect(1).to eq(1)
+    describe 'attributes' do
+      it 'cloudlet_id' do
+        expect(subject.instance_variable_get(:@cloudlet_id)).to eq('123')
+      end
+
+      it 'group_id' do
+        expect(subject.instance_variable_get(:@group_id)).to eq('456')
+      end
     end
   end
 end

--- a/spec/akamai_cloudlet_manager/detail_spec.rb
+++ b/spec/akamai_cloudlet_manager/detail_spec.rb
@@ -4,7 +4,15 @@ require 'spec_helper'
 RSpec.describe AkamaiCloudletManager::Detail do
 
   describe '#initialize' do
-    subject { AkamaiCloudletManager::Detail.new({ cloudlet_id: '123', group_id: '456' }) }
+
+    subject {
+      AkamaiCloudletManager::Detail.new({
+        path_to_edgerc: AkamaiCloudletManager.spec + '/test_edgerc',
+        section:        'test_edgerc',
+        cloudlet_id:    '123',
+        group_id:       '456'
+      })
+    }
 
     describe 'attributes' do
       it 'cloudlet_id' do

--- a/spec/akamai_cloudlet_manager/detail_spec.rb
+++ b/spec/akamai_cloudlet_manager/detail_spec.rb
@@ -15,13 +15,14 @@ RSpec.describe AkamaiCloudletManager::Detail do
     }
 
     describe 'attributes' do
-      it 'cloudlet_id' do
+      it 'has cloudlet_id' do
         expect(subject.instance_variable_get(:@cloudlet_id)).to eq('123')
       end
 
-      it 'group_id' do
+      it 'has group_id' do
         expect(subject.instance_variable_get(:@group_id)).to eq('456')
       end
     end
   end
+
 end

--- a/spec/akamai_cloudlet_manager/policy_spec.rb
+++ b/spec/akamai_cloudlet_manager/policy_spec.rb
@@ -4,7 +4,13 @@ require 'spec_helper'
 RSpec.describe AkamaiCloudletManager::Policy do
 
   describe '#initialize' do
-    subject { AkamaiCloudletManager::Policy.new({ policy_id: '123' }) }
+    subject {
+      AkamaiCloudletManager::Policy.new({
+        path_to_edgerc: AkamaiCloudletManager.spec + '/test_edgerc',
+        section:        'test_edgerc',
+        policy_id:      '123'
+      })
+    }
 
     context 'attributes' do
       it 'policy_id' do

--- a/spec/akamai_cloudlet_manager/policy_spec.rb
+++ b/spec/akamai_cloudlet_manager/policy_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+
+RSpec.describe AkamaiCloudletManager::Policy do
+
+  describe '#initialize' do
+    subject { AkamaiCloudletManager::Policy.new({ policy_id: '123' }) }
+
+    context 'attributes' do
+      it 'policy_id' do
+        expect(subject.instance_variable_get(:@policy_id)).to eq('123')
+      end
+    end
+  end
+end

--- a/spec/akamai_cloudlet_manager/policy_version_spec.rb
+++ b/spec/akamai_cloudlet_manager/policy_version_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+
+RSpec.describe AkamaiCloudletManager::PolicyVersion do
+
+  describe '#initialize' do
+    subject { AkamaiCloudletManager::PolicyVersion.new({ policy_id: '123', version_id: '456' }) }
+
+    context 'attributes' do
+      it 'policy_id' do
+        expect(subject.instance_variable_get(:@policy_id)).to eq('123')
+      end
+
+      it 'version_id' do
+        expect(subject.instance_variable_get(:@version_id)).to eq('456')
+      end
+    end
+  end
+end

--- a/spec/akamai_cloudlet_manager/policy_version_spec.rb
+++ b/spec/akamai_cloudlet_manager/policy_version_spec.rb
@@ -4,7 +4,14 @@ require 'spec_helper'
 RSpec.describe AkamaiCloudletManager::PolicyVersion do
 
   describe '#initialize' do
-    subject { AkamaiCloudletManager::PolicyVersion.new({ policy_id: '123', version_id: '456' }) }
+    subject {
+      AkamaiCloudletManager::PolicyVersion.new({
+        path_to_edgerc: AkamaiCloudletManager.spec + '/test_edgerc',
+        section:        'test_edgerc',
+        policy_id:      '123',
+        version_id:     '456'
+      })
+    }
 
     context 'attributes' do
       it 'policy_id' do

--- a/spec/fixtures/path_patterns.txt
+++ b/spec/fixtures/path_patterns.txt
@@ -1,0 +1,2 @@
+/random/path1
+/random/path2

--- a/spec/test_edgerc
+++ b/spec/test_edgerc
@@ -1,0 +1,6 @@
+[test_edgerc]
+client_secret = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
+host = akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/
+access_token = akab-access-token-xxx-xxxxxxxxxxxxxxxx
+client_token = akab-client-token-xxx-xxxxxxxxxxxxxxxx
+max-body = 131072


### PR DESCRIPTION
This PR includes:

- [x] Basic Specs
- [x] Commands to activate policy version

Here is sample _acm --help_

```sh
Commands:
  acm activate_policy_version --network=NETWORK --policy-id=POLICY_ID --version=VERSION                # Activate the policy version on a given network(staging/production)
  acm clone_policy_version --policy-id=POLICY_ID                                                       # Clones the current policy version
  acm get_policy_version --policy-id=POLICY_ID                                                         # Get policy versions
  acm help [COMMAND]                                                                                   # Describe available commands or one specific command
  acm update_policy_version --draft-version=DRAFT_VERSION --file-path=FILE_PATH --policy-id=POLICY_ID  # Updates the policy version
```
  