### PR TITLE
CLI updated with better and readable output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     akamai_cloudlet_manager (0.0.1)
       akamai-edgegrid (~> 1.0, >= 1.0.6)
       json (~> 2.1)
+      terminal-table (~> 1.8)
       thor (~> 0.20.0)
 
 GEM
@@ -28,15 +29,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.0)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   akamai_cloudlet_manager!
-  rake
+  rake (~> 12.2, >= 12.2.1)
   rspec (~> 3.7)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Akamai API for changes to Property Manager etc via CLI
 
-[![Build Status](https://travis-ci.org/gouravtiwari/akamai-cloudlet-updater.svg?branch=master)](https://travis-ci.org/gouravtiwari/akamai-cloudlet-updater) [![Maintainability](https://api.codeclimate.com/v1/badges/9c35e419deec5c546f4e/maintainability)](https://codeclimate.com/github/gouravtiwari/akamai-cloudlet-manager/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/9c35e419deec5c546f4e/test_coverage)](https://codeclimate.com/github/gouravtiwari/akamai-cloudlet-manager/test_coverage)
+[![Build Status](https://travis-ci.org/gouravtiwari/akamai-cloudlet-manager.svg?branch=master)](https://travis-ci.org/gouravtiwari/akamai-cloudlet-manager) [![Maintainability](https://api.codeclimate.com/v1/badges/9c35e419deec5c546f4e/maintainability)](https://codeclimate.com/github/gouravtiwari/akamai-cloudlet-manager/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/9c35e419deec5c546f4e/test_coverage)](https://codeclimate.com/github/gouravtiwari/akamai-cloudlet-manager/test_coverage)
 
 ## Setup
 

--- a/akamai_cloudlet_manager.gemspec
+++ b/akamai_cloudlet_manager.gemspec
@@ -15,10 +15,11 @@ Gem::Specification.new do |s|
                  ]
   s.executables << 'acm'
   s.homepage    = 'https://github.com/gouravtiwari/akamai-cloudlet-manager'
-  s.license       = 'MIT'
+  s.license       = 'Apache License'
   s.add_runtime_dependency 'akamai-edgegrid', '~> 1.0', '>= 1.0.6'
   s.add_runtime_dependency 'json', '~> 2.1'
+  s.add_development_dependency 'rake' , '~> 12.2', '>= 12.2.1'
   s.add_runtime_dependency 'thor', '~> 0.20.0'
   s.add_development_dependency 'rspec', '~> 3.7'
-  s.add_development_dependency 'rake'
+  s.add_runtime_dependency 'terminal-table', '~> 1.8'
 end

--- a/bin/acm
+++ b/bin/acm
@@ -2,6 +2,8 @@
 
 require 'akamai_cloudlet_manager'
 require 'thor'
+require 'json'
+require 'terminal-table'
 
 class AkamaiCloudletManagerCli < Thor
 
@@ -12,9 +14,12 @@ class AkamaiCloudletManagerCli < Thor
     LONGDESC
   method_option :policy_id, required: true
   def get_policy_versions
-    puts "Policy version:"
+    puts "Policy versions:"
     policy_version = AkamaiCloudletManager::PolicyVersion.new({policy_id: options[:policy_id] })
-    puts policy_version.versions
+    rows_title = ['Location','Revision','Description']
+    rows = JSON.parse(policy_version.versions).collect {|i| [i['location'], i['revisionId'], i['description']]}
+    rows.unshift(rows_title)
+    puts Terminal::Table.new rows: rows
   end
 
   desc "clone_policy_version", "Clones the current policy version"


### PR DESCRIPTION
- CLI updated
```
agupta@agupta01scl ~/D/p/p/akamai-cloudlet-updater> acm get_policy_versions --policy-id="38548"
Policy versions:
+---------------------------------------------+----------+---------------------------------------------------+
| Location                                    | Revision | Description                                       |
| /cloudlets/api/v2/policies/38548/versions/4 | 1086058  | use threshold_value cookie for ajax call, testing |
| /cloudlets/api/v2/policies/38548/versions/3 | 1086052  |                                                   |
| /cloudlets/api/v2/policies/38548/versions/2 | 1084925  | Same as version 1, just updating via API          |
| /cloudlets/api/v2/policies/38548/versions/1 | 1082822  | initial version                                   |
+---------------------------------------------+----------+---------------------------------------------------+
```

- License updated